### PR TITLE
Dion user group queries

### DIFF
--- a/api/supabase/createClient.ts
+++ b/api/supabase/createClient.ts
@@ -1,7 +1,4 @@
 import { createClient } from "@supabase/supabase-js";
-import dotenv from "dotenv";
-
-dotenv.config();
 
 if (
   !process.env.NEXT_PUBLIC_SUPABASE_URL ||

--- a/api/supabase/queries/user-groups.ts
+++ b/api/supabase/queries/user-groups.ts
@@ -1,0 +1,22 @@
+import supabase from "../createClient";
+
+export async function fetchUserGroups() {
+  try {
+    // Pull data
+    const { data, error } = await supabase.from("user_group").select("*");
+
+    if (error) throw error;
+
+    // Process data
+    if (data) {
+      const mapped = data.map(usergrp => ({
+        id: usergrp.user_group_id,
+        user_group_name: usergrp.user_group_name,
+      }));
+
+      return mapped;
+    }
+  } catch (error) {
+    console.log("Error fetching orgs data from supabase API: ", error);
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,14 @@
 import { CSSProperties } from "react";
 import Image from "next/image";
+import UserGroupsPage from "@/app/user_groups/page";
 import BPLogo from "@/assets/images/bp-logo.png";
-import UserGroupsPage from "@/app/user_groups/page"
 
 export default function Home() {
   return (
     <main style={mainStyles}>
       <Image style={imageStyles} src={BPLogo} alt="Blueprint Logo" />
       <p>Open up app/page.tsx to get started!</p>
-      <UserGroupsPage/>
+      <UserGroupsPage />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 import { CSSProperties } from "react";
 import Image from "next/image";
 import BPLogo from "@/assets/images/bp-logo.png";
+import UserGroupsPage from "@/app/user_groups/page"
 
 export default function Home() {
   return (
     <main style={mainStyles}>
       <Image style={imageStyles} src={BPLogo} alt="Blueprint Logo" />
       <p>Open up app/page.tsx to get started!</p>
+      <UserGroupsPage/>
     </main>
   );
 }

--- a/app/user_groups/page.tsx
+++ b/app/user_groups/page.tsx
@@ -1,53 +1,45 @@
-"use client"
+"use client";
 
-import supabase from "@/actions/supabase/client"
+import { useEffect, useState } from "react";
+import supabase from "@/actions/supabase/client";
 import { UserGroup } from "@/types/schema";
-import { useState, useEffect } from "react";
 
 const UserGroupsPage = () => {
+  const [userGroups, setUserGroups] = useState<UserGroup[]>([]);
 
-  const [userGroups, setUserGroups] = useState<UserGroup[]>([])
-  
   useEffect(() => {
     async function fetchUserGroups() {
       try {
         // Pull data
-        const { data, error } = await supabase
-        .from('user_group')
-        .select('*')
+        const { data, error } = await supabase.from("user_group").select("*");
 
-        if (error) throw error
+        if (error) throw error;
 
         // Process data
         if (data) {
-          const mapped = data.map((usergrp) => ({
+          const mapped = data.map(usergrp => ({
             id: usergrp.user_group_id,
-            user_group_name: usergrp.user_group_name
-          }))
+            user_group_name: usergrp.user_group_name,
+          }));
 
-          setUserGroups(mapped)
-        }      
+          setUserGroups(mapped);
+        }
       } catch (error) {
-        console.log("Error fetching orgs data from supabase API: ", error)
+        console.log("Error fetching orgs data from supabase API: ", error);
       }
     }
-    
-    fetchUserGroups()
-  }, [])
+
+    fetchUserGroups();
+  }, []);
 
   return (
     <div>
-      <h1>User Groups</h1>      
-      {
-        userGroups.map((usergrp, index) => (
-          <div key={index}>
-            {usergrp.user_group_name}
-          </div>
-        ))
-      }
+      <h1>User Groups</h1>
+      {userGroups.map((usergrp, index) => (
+        <div key={index}>{usergrp.user_group_name}</div>
+      ))}
     </div>
   );
 };
 
-
-export default UserGroupsPage
+export default UserGroupsPage;

--- a/app/user_groups/page.tsx
+++ b/app/user_groups/page.tsx
@@ -1,35 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import supabase from "@/actions/supabase/client";
+import { fetchUserGroups } from "@/api/supabase/queries/user-groups";
 import { UserGroup } from "@/types/schema";
 
 const UserGroupsPage = () => {
   const [userGroups, setUserGroups] = useState<UserGroup[]>([]);
 
   useEffect(() => {
-    async function fetchUserGroups() {
-      try {
-        // Pull data
-        const { data, error } = await supabase.from("user_group").select("*");
-
-        if (error) throw error;
-
-        // Process data
-        if (data) {
-          const mapped = data.map(usergrp => ({
-            id: usergrp.user_group_id,
-            user_group_name: usergrp.user_group_name,
-          }));
-
-          setUserGroups(mapped);
-        }
-      } catch (error) {
-        console.log("Error fetching orgs data from supabase API: ", error);
+    async function loadUserGroups() {
+      const fetchedUserGrps = await fetchUserGroups();
+      if (fetchedUserGrps) {
+        setUserGroups(fetchedUserGrps);
       }
     }
 
-    fetchUserGroups();
+    loadUserGroups();
   }, []);
 
   return (

--- a/app/user_groups/page.tsx
+++ b/app/user_groups/page.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import supabase from "@/actions/supabase/client"
+import { UserGroup } from "@/types/schema";
+import { useState, useEffect } from "react";
+
+const UserGroupsPage = () => {
+
+  const [userGroups, setUserGroups] = useState<UserGroup[]>([])
+  
+  useEffect(() => {
+    async function fetchUserGroups() {
+      try {
+        // Pull data
+        const { data, error } = await supabase
+        .from('user_group')
+        .select('*')
+
+        if (error) throw error
+
+        // Process data
+        if (data) {
+          const mapped = data.map((usergrp) => ({
+            id: usergrp.user_group_id,
+            user_group_name: usergrp.user_group_name
+          }))
+
+          setUserGroups(mapped)
+        }      
+      } catch (error) {
+        console.log("Error fetching orgs data from supabase API: ", error)
+      }
+    }
+    
+    fetchUserGroups()
+  }, [])
+
+  return (
+    <div>
+      <h1>User Groups</h1>      
+      {
+        userGroups.map((usergrp, index) => (
+          <div key={index}>
+            {usergrp.user_group_name}
+          </div>
+        ))
+      }
+    </div>
+  );
+};
+
+
+export default UserGroupsPage


### PR DESCRIPTION
## 🦜 What's new in this PR
### 🦋 Description
- Added user-group dir with page.tsx
- Added queries dir with user-group.ts
- removed dotenv from supabase client, createClient.ts, found error when trying to use supbase cilent to fetch user-groups on render

### 🦧 Screenshots
final ss:
<img width="479" height="359" alt="image" src="https://github.com/user-attachments/assets/d7765475-3f4c-473a-8492-295fb20c8151" />

error obtained if dotenv is used in createClient.ts, i think its bc dontenv cant run client side. My page.tsx component needs to be run cilent side as it requires useState and useEffect, and it calls the user-groups.ts script which creates a client side client. Not sure if this is right or if you wanted the client to be only created server side.

<img width="1033" height="732" alt="image" src="https://github.com/user-attachments/assets/93344d1b-0196-40f0-8078-9bf79d83383c" />


## 🐸 How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'


## 🐙 Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."


## 🐆 Relevant links
### Online sources
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'


### 🐁 Related PRs
[//]: # "Add related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"


CC: @me-liu