### PR TITLE
advance_phase rpc testing page

### DIFF
--- a/app/test-advance-phase/page.tsx
+++ b/app/test-advance-phase/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import supabase from "@/actions/supabase/client";
+
+export default function TestRPC() {
+  // hardcoded values for testing
+  const SESSION_ID = "0c50c7cf-8e27-41de-9252-e17201ea6f70";
+  const CURRENT_PHASE_NUMBER = 1;
+
+  const [result, setResult] = useState<string | null>(null);
+
+  async function runTest() {
+    setResult("Running...");
+
+    const { data, error } = await supabase.rpc("advance_phase", {
+      p_session_id: SESSION_ID,
+      p_current_phase_num: CURRENT_PHASE_NUMBER,
+    });
+
+    if (error) {
+      setResult("Error: " + error.message);
+    } else if (data === null) {
+      setResult("Final phase.");
+    } else {
+      setResult("Next phase_id: " + data);
+    }
+  }
+
+  return (
+    <div>
+      <h1>RPC Test: advance_to_next_phase</h1>
+
+      <p>Session ID:{SESSION_ID}</p>
+      <p>Current Phase Number:{CURRENT_PHASE_NUMBER}</p>
+
+      <button onClick={runTest}>Run RPC</button>
+
+      {result && <p>{result}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## 🦜 What's new in this PR
### 🦋 Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

Advance_phase RPC: 
advance_phase(current_phase int, session_id uuid)
 - returns next phase_id (uuid)
 - if there is no more phases after, then returns null
 - advances all participants with the same session_id to that new phase_id
 - updates session table to the new phase_id

/test-advance-phase:
- testing page 
- session_id and current_phase_int and hardcoded into the file
- button to test rpc

## 🐸 How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

- check advance_phase in database/functions/advance-phase
Testing set up:
- phase has 3 phases with phase_number 1, 2, 3 with the session_id "0c50c7cf-8e27-41de-9252-e17201ea6f70"
- testing page already starts at 1
- click next phase
- should print the next phase_id (check supabase to see if this is right)
- check participant_session to see if the is_finished in now False and the session_id is correct (might want to put in Trues and random session_ids to see if it changes)
- check sessions to see if the phase_id updates (when i tested this, it took a little longer to update than the participant sessions)
- go to code... and update phase_numeber to 2 and 3
- same thing for 2, at 3 it should return that that is the last phase



## 🐆 Relevant links
### Online sources
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'
[video that helped](https://www.youtube.com/watch?v=I6nnp9AINJk&t=7s) 


CC: @me-liu