### PR TITLE
[bug] fix sign up flow

### DIFF
--- a/actions/supabase/queries/auth.ts
+++ b/actions/supabase/queries/auth.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { createClient } from "@supabase/supabase-js";
-import { getSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  getSupabaseAdminClient,
+  getSupabaseServerClient,
+} from "@/lib/supabase/server";
 import { Invite } from "@/types/schema";
 
 export async function checkInviteStatus(email: string) {
@@ -136,6 +139,52 @@ export async function checkIfUserExists(email: string): Promise<boolean> {
   }
 
   return data !== null && data.length > 0;
+}
+
+export async function signUpInvitedUser(email: string, password: string) {
+  const adminClient = getSupabaseAdminClient();
+  const lowerCaseEmail = email.toLowerCase();
+
+  const { status } = await checkInviteStatus(lowerCaseEmail);
+  if (status !== "pending") {
+    return {
+      success: false,
+      error: "No pending invitation found for this email",
+      userId: null,
+    };
+  }
+
+  const { data, error } = await adminClient.auth.admin.createUser({
+    email: lowerCaseEmail,
+    password: password,
+    email_confirm: true,
+  });
+
+  if (error) {
+    console.error("Error creating user:", error.message);
+    return { success: false, error: error.message, userId: null };
+  }
+
+  if (!data.user) {
+    return { success: false, error: "Failed to create user", userId: null };
+  }
+
+  const userId = data.user.id;
+
+  try {
+    await addInviteInfoToProfile(userId, lowerCaseEmail);
+    await markInviteAccepted(lowerCaseEmail);
+
+    return { success: true, error: null, userId };
+  } catch (err) {
+    console.error("Error signing up invited user:", err);
+    return {
+      success: false,
+      error:
+        err instanceof Error ? err.message : "Failed to sign up invited user",
+      userId: null,
+    };
+  }
 }
 
 /* returns True if there is an unaccepted invite given an email*/

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -5,9 +5,8 @@ import { FiCheck, FiEye, FiEyeOff, FiX } from "react-icons/fi";
 import { useRouter } from "next/navigation";
 import supabase from "@/actions/supabase/client";
 import {
-  addInviteInfoToProfile,
   checkInviteStatus,
-  markInviteAccepted,
+  signUpInvitedUser,
 } from "@/actions/supabase/queries/auth";
 import {
   Button,
@@ -136,24 +135,27 @@ export default function SignUp() {
         return;
       }
 
-      const { data, error } = await supabase.auth.signUp({
-        email: email,
-        password: password,
-      });
+      const result = await signUpInvitedUser(email, password);
 
-      if (error) {
-        setErrorMessage("Error creating account: " + error.message);
+      if (!result.success || !result.userId) {
+        setErrorMessage(result.error || "Failed to create account");
         return;
       }
 
-      const userId = data.user?.id;
-      if (!userId) {
-        setErrorMessage("Something went wrong. Please try again.");
+      // sign in the user to create a session
+      const { data: signInData, error: signInError } =
+        await supabase.auth.signInWithPassword({
+          email: email,
+          password: password,
+        });
+
+      if (signInError || !signInData.session) {
+        setErrorMessage(
+          "Account created but failed to sign in. Please try signing in manually.",
+        );
         return;
       }
 
-      await addInviteInfoToProfile(userId, email);
-      await markInviteAccepted(email);
       router.push("/onboarding");
     } catch (error: unknown) {
       if (error instanceof Error) {

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { createServerClient as createServerClientSB } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
 import { Database } from "../../types/database.types";
 
 export async function getSupabaseServerClient() {
@@ -33,6 +34,28 @@ export async function getSupabaseServerClient() {
             }
           });
         },
+      },
+    },
+  );
+}
+
+export function getSupabaseAdminClient() {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    throw new Error(
+      "Missing Supabase URL or Service Role Key. Make sure SUPABASE_SERVICE_ROLE_KEY is set in your environment variables.",
+    );
+  }
+
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
       },
     },
   );

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -39,6 +39,8 @@ export async function getSupabaseServerClient() {
   );
 }
 
+// This client has full admin privileges, including bypassing RLS
+// Do NOT use this client in client-side code, only in server-side code
 export function getSupabaseAdminClient() {
   if (
     !process.env.NEXT_PUBLIC_SUPABASE_URL ||


### PR DESCRIPTION
## 🦜 What's new in this PR
### 🦋 Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

- fixed bug where the sign-up flow did not have a session for onboarding
- `signUpInvited User` creates a user without any session via `getSupabaseAdminClient` which has complete admin privileges
- creates a session prior to routing to onboarding by signing in the user


## 🐸 How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

- first check that the email that you are using to test is not a registered user in the `invite` table and the authenticated `Users` table
- invite your email in `../facilitator/participants`, go to `../auth/sign-up`, check that you're able to sign up with your password, onboard, check that the data on supabase matches, sign out, sign back in

## 🐙 Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."

- need to implement a one-time password to prevent people from signing up with emails that are not theirs, and have `../facilitator/participants` reflect when the users accept the OTP.
- heard from @eshabansiya that we're not proceeding with the magic links sent from email, so we should remove that


## 🐆 Relevant links
### Online sources
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'



### 🐁 Related PRs
[//]: # "Add related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"



CC: @me-liu